### PR TITLE
Remove Waypoints

### DIFF
--- a/gamemode/core/sh_state.lua
+++ b/gamemode/core/sh_state.lua
@@ -296,6 +296,7 @@ function JB:NewRound(rounds_passed)
 			JB.TRANSMITTER:SetJBWarden_PVPDamage(false);
 			JB.TRANSMITTER:SetJBWarden_ItemPickup(false);
 			JB.TRANSMITTER:SetJBWarden_PointerType("0");
+			JB.TRANSMITTER:SetJBWarden_GreenPointerType("0");
 			JB.TRANSMITTER:SetJBWarden(NULL);
 		end
 


### PR DESCRIPTION
This update fixes a small oversight which prevented a green waypoint from being removed at the start of a round.